### PR TITLE
refactor test:

### DIFF
--- a/test/elasticsearch/model/transactional_callbacks/queue_test.rb
+++ b/test/elasticsearch/model/transactional_callbacks/queue_test.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require_relative '../transactional_callbacks_test'
 
 module Elasticsearch::Model::TransactionalCallbacks
-  class Queue::Test < Test
+  class Queue::Test < BaseTest
     attr_reader :queue
 
     setup do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,3 +23,5 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + '/files'
   ActiveSupport::TestCase.fixtures :all
 end
+
+require_relative './elasticsearch/model/transactional_callbacks/base'


### PR DESCRIPTION
- move base class into `BaseTest`, we'll use TransactionalCallbacks::Test
  to test patches applied to ActiveRecord::Base.transaction later

- index fixtures data by default, it's easier to reason about when db
  and index are synced

- clarify test intention by introducing several custom assertion